### PR TITLE
Json Property Naming Error in PokemonMoveVersion

### DIFF
--- a/PokeApiNet/Models/Pokemon.cs
+++ b/PokeApiNet/Models/Pokemon.cs
@@ -620,7 +620,7 @@ namespace PokeApiNet.Models
         /// <summary>
         /// The method by which the move is learned.
         /// </summary>
-        [JsonProperty("move_learned_method")]
+        [JsonProperty("move_learn_method")]
         public NamedApiResource<MoveLearnMethod> MoveLearnMethod { get; set; }
 
         /// <summary>


### PR DESCRIPTION
The JSON property for `move_learn_method` was named `move_learned_method`