### PR TITLE
Added constructor accepting HttpClient

### DIFF
--- a/PokeApiNet/PokeApiClient.cs
+++ b/PokeApiNet/PokeApiClient.cs
@@ -75,6 +75,23 @@ namespace PokeApiNet
         }
 
         /// <summary>
+        /// Construct accepting directly a HttpClient. Useful when used in projects where IHttpClientFactory is used to create and configure HttpClient instances with different policies.
+        /// See https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public PokeApiClient(HttpClient httpClient)
+        {
+            if (httpClient == null)
+            {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
+
+            _client = httpClient;
+            _client.BaseAddress = _baseUri;
+        }
+
+        /// <summary>
         /// Close resources
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
Hi, I added a ctor accepting directly an HttpClient. This is useful when using the library inside a ASP.NET Core API project, as it allows the client to be created using IHttpClientFactory (https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests) to avoid socket exhausting and to make the HttpClient configurable (for usage with Polly, for example)