### PR TITLE
[DO NOT MERGE] Add property to Pokemon model containing its past types

### DIFF
--- a/PokeApiNet.Tests/IntegrationTests.cs
+++ b/PokeApiNet.Tests/IntegrationTests.cs
@@ -1371,5 +1371,88 @@ namespace PokeApiNet.Tests
             // assert
             Assert.True(page.Results.Any());
         }
+
+        /// <summary>
+        /// Verifies that Pokemon with past types data have theirs fetched correctly.
+        /// </summary>
+        [Theory]
+        [InlineData(35, 5, 1, 1)]
+        [InlineData(36, 5, 1, 1)]
+        [InlineData(39, 5, 1, 1)]
+        [InlineData(40, 5, 1, 1)]
+        [InlineData(81, 1, 13, 1)]
+        [InlineData(82, 1, 13, 1)]
+        [InlineData(122, 5, 14, 1)]
+        [InlineData(173, 5, 1, 1)]
+        [InlineData(174, 5, 1, 1)]
+        [InlineData(175, 5, 1, 1)]
+        [InlineData(176, 5, 1, 1)] [InlineData(176, 5, 3, 2)]
+        [InlineData(183, 5, 11, 1)]
+        [InlineData(184, 5, 11, 1)]
+        [InlineData(209, 5, 1, 1)]
+        [InlineData(210, 5, 1, 1)]
+        [InlineData(280, 5, 14, 1)]
+        [InlineData(281, 5, 14, 1)]
+        [InlineData(282, 5, 14, 1)]
+        [InlineData(298, 5, 1, 1)]
+        [InlineData(303, 5, 9, 1)]
+        [InlineData(439, 5, 14, 1)]
+        [InlineData(468, 5, 1, 1)] [InlineData(468, 5, 3, 2)]
+        [InlineData(546, 5, 12, 1)]
+        [InlineData(10008, 4, 13, 1)] [InlineData(10008, 4, 8, 2)]
+        [InlineData(10009, 4, 13, 1)] [InlineData(10009, 4, 8, 2)]
+        [InlineData(10010, 4, 13, 1)] [InlineData(10010, 4, 8, 2)]
+        [InlineData(10011, 4, 13, 1)] [InlineData(10011, 4, 8, 2)]
+        [InlineData(10012, 4, 13, 1)] [InlineData(10012, 4, 8, 2)]
+        public static async Task GetPastTypesTest_HasPastTypes(int pokemonID, int generation, int type, int slot)
+        {
+            // assemble
+            using (var client = new PokeApiClient())
+            {
+                // act
+                var pokemon = await client.GetResourceAsync<Pokemon>(pokemonID);
+
+                // assert
+                var pastTypes = pokemon.PastTypes;
+                Assert.NotNull(pastTypes);
+                Assert.NotEmpty(pastTypes);
+
+                // verify this pokemon has past type data for the given generation
+                var generations = await client.GetResourceAsync(pastTypes.Select(p => p.Generation));
+                var generationObj = generations.SingleOrDefault(g => g.Id == generation);
+                Assert.NotNull(generationObj);
+
+                // verify that this generation's past type data has an entry for the given slot
+                var types = pastTypes.Single(p => p.Generation.Name == generationObj.Name).Types;
+                var typeObj = types.SingleOrDefault(t => t.Slot == slot);
+                Assert.NotNull(typeObj);
+
+                // verify that this slot's type is correct
+                var typeRes = await client.GetResourceAsync(typeObj.Type);
+                Assert.Equal(typeRes.Id, type);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a Pokemon with no past types data
+        /// has an empty list as its PastTypes property.
+        /// </summary>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public static async Task GetPastTypesTest_NoPastTypes(int pokemonID)
+        {
+            // assemble
+            using (var client = new PokeApiClient())
+            {
+                // act
+                var pokemon = await client.GetResourceAsync<Pokemon>(pokemonID);
+
+                // assert
+                var pastTypes = pokemon.PastTypes;
+                Assert.Empty(pastTypes);
+            }
+        }
     } 
 }

--- a/PokeApiNet/Models/Common.cs
+++ b/PokeApiNet/Models/Common.cs
@@ -168,6 +168,23 @@ namespace PokeApiNet.Models
         public string Name { get; set; }
     }
 
+    /// <summary>
+    /// Class representing data from a previous generation.
+    /// </summary>
+    /// <typeparam name="TData">The type of the data.</typeparam>
+    public class PastGenerationData<TData>
+    {
+        /// <summary>
+        /// The final generation in which the Pokemon had the given data.
+        /// </summary>
+        public NamedApiResource<Generation> Generation { get; set; }
+
+        /// <summary>
+        /// The previous data.
+        /// </summary>
+        protected TData Data { get; set; }
+    }
+
     public class VerboseEffect
     {
         /// <summary>

--- a/PokeApiNet/Models/Pokemon.cs
+++ b/PokeApiNet/Models/Pokemon.cs
@@ -531,6 +531,12 @@ namespace PokeApiNet.Models
         public List<PokemonMove> Moves { get; set; }
 
         /// <summary>
+        /// Type data in previous generations for this Pokemon.
+        /// </summary>
+        [JsonProperty("past_types")]
+        public List<PokemonPastTypes> PastTypes { get; set; }
+
+        /// <summary>
         /// A set of sprites used to depict this Pokémon in the game.
         /// </summary>
         public PokemonSprites Sprites { get; set; }

--- a/PokeApiNet/Models/Pokemon.cs
+++ b/PokeApiNet/Models/Pokemon.cs
@@ -583,6 +583,21 @@ namespace PokeApiNet.Models
         public NamedApiResource<Type> Type { get; set; }
     }
 
+    /// <summary>
+    /// Class for storing a Pokemon's type data in a previous generation.
+    /// </summary>
+    public class PokemonPastTypes : PastGenerationData<List<PokemonType>>
+    {
+        /// <summary>
+        /// The previous list of types.
+        /// </summary>
+        public List<PokemonType> Types
+        {
+            get => Data;
+            set { Data = value; }
+        }
+    }
+
     public class PokemonHeldItem
     {
         /// <summary>


### PR DESCRIPTION
This PR adds a property to the Pokemon model containing its past types.

The data was added to PokeAPI in this PR: https://github.com/PokeAPI/pokeapi/pull/457

This should NOT be merged until the data is available in the production deployment of PokeAPI; it is currently only available in the staging deployment, e.g. https://staging.pokeapi.co/api/v2/pokemon/35/.